### PR TITLE
Default login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ You can add a ReturnUrl to redirect the user once they are logged in, for exampl
 
 Vipps is using the OpenIdConnect Authorization Code Grant flow, this means the user is redirected back to your environment with a Authorization token. The middleware will validate the token and exchange it for an `id_token` and an `access_token`. A `ClaimsIdentity` will be created which will contain the information of the scopes that you configured (email, name, addresses etc).
 
+### Customized 'sanity check' during login
+
+If the user tries to log in with Vipps and there is an existing account that matches the Vipps information (email or phone number), the library will execute a 'sanity check'. This is done to make sure that the account is not an old account where the user has abandoned the phone number or e-mail address an this has been picked up by someone else at a later time.
+By default it will compare the first name and the last name, however it is easy to change this behaviour by implementing a custom sanity check and registering it in the DI container:
+
+```csharp
+public class VippsLoginSanityCheck : IVippsLoginSanityCheck
+{
+    public bool IsValidContact(CustomerContact contact, VippsUserInfo userInfo)
+    {
+        // your logic here
+    }
+}
+```
+
 ### Accessing Vipps user data
 
 The Vipps UserInfo can be accessed by calling `IVippsLoginService.GetVippsUserInfo(IIdentity identity)`, this will give you the user info that was retrieved when the user logged in (cached).

--- a/src/Vipps.Login.Episerver.Commerce/AddressExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/AddressExtensions.cs
@@ -40,18 +40,5 @@ namespace Vipps.Login.Episerver.Commerce
             }
             return null;
         }
-
-        public static void MapVippsAddress(
-            this CustomerAddress address,
-            VippsAddress vippsAddress
-        )
-        {
-            if (vippsAddress == null) throw new ArgumentNullException(nameof(vippsAddress));
-            address.Line1 = vippsAddress.StreetAddress;
-            address.City = vippsAddress.Region;
-            address.PostalCode = vippsAddress.PostalCode;
-            address.CountryCode = vippsAddress.Country;
-            address.SetVippsAddressType(vippsAddress.AddressType);
-        }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/CustomerContactExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/CustomerContactExtensions.cs
@@ -16,18 +16,6 @@ namespace Vipps.Login.Episerver.Commerce
             return contact[MetadataConstants.VippsSubjectGuidFieldName] as Guid?;
         }
 
-        public static void MapVippsUserInfo(
-            this CustomerContact contact,
-            VippsUserInfo userInfo
-        )
-        {
-            if (userInfo == null) throw new ArgumentNullException(nameof(userInfo));
-            contact.Email = userInfo.Email;
-            contact.FirstName = userInfo.GivenName;
-            contact.LastName = userInfo.FamilyName;
-            contact.FullName = userInfo.Name;
-            contact.BirthDate = userInfo.BirthDate;
-            contact.SetVippsSubject(userInfo.Sub);
-        }
+        
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginDuplicateAccountException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginDuplicateAccountException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Vipps.Login.Episerver.Commerce
+namespace Vipps.Login.Episerver.Commerce.Exceptions
 {
     public class VippsLoginDuplicateAccountException : Exception
     {

--- a/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vipps.Login.Episerver.Commerce.Exceptions
+{
+    public class VippsLoginException : Exception
+    {
+        public VippsLoginException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginSanityCheckException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginSanityCheckException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vipps.Login.Episerver.Commerce.Exceptions
+{
+    public class VippsLoginSanityCheckException : Exception
+    {
+        public VippsLoginSanityCheckException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Extensions/AddressExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Extensions/AddressExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using Mediachase.Commerce.Customers;
 using Vipps.Login.Models;
 
-namespace Vipps.Login.Episerver.Commerce
+namespace Vipps.Login.Episerver.Commerce.Extensions
 {
     public static class AddressExtensions
     {

--- a/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using Mediachase.Commerce.Customers;
-using Vipps.Login.Models;
 
-namespace Vipps.Login.Episerver.Commerce
+namespace Vipps.Login.Episerver.Commerce.Extensions
 {
     public static class CustomerContactExtensions
     {

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
@@ -7,7 +7,7 @@ namespace Vipps.Login.Episerver.Commerce
 {
     public interface IVippsLoginCommerceService
     {
-        IEnumerable<CustomerContact> FindCustomerContacts(Guid subjectGuid);
+        CustomerContact FindCustomerContact(Guid subjectGuid);
         IEnumerable<CustomerContact> FindCustomerContacts(string email, string phone);
         void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default);
     }

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Principal;
+using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public interface IVippsLoginCommerceService
+    {
+        IEnumerable<CustomerContact> FindCustomerContacts(Guid subjectGuid);
+        IEnumerable<CustomerContact> FindCustomerContacts(string email, string phone);
+        void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default);
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginDataLoader.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginDataLoader.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public interface IVippsLoginDataLoader
+    {
+        IEnumerable<CustomerContact> FindContactsBySubjectGuid(Guid subjectGuid);
+        IEnumerable<CustomerContact> FindContactsByEmail(string email);
+        IEnumerable<CustomerContact> FindContactsByPhone(string phone);
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginMapper.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginMapper.cs
@@ -14,5 +14,12 @@ namespace Vipps.Login.Episerver.Commerce
             CustomerAddress address,
             VippsAddress vippsAddress
         );
+
+        void MapAddress(
+            CustomerContact currentContact,
+            CustomerAddressTypeEnum addressType,
+            VippsAddress vippsAddress,
+            string phoneNumber
+        );
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginMapper.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginMapper.cs
@@ -1,0 +1,18 @@
+﻿using Mediachase.Commerce.Customers;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public interface IVippsLoginMapper
+    {
+        void MapVippsContactFields(
+            CustomerContact contact,
+            VippsUserInfo userInfo
+        );
+
+        void MapVippsAddressFields(
+            CustomerAddress address,
+            VippsAddress vippsAddress
+        );
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginSanityCheck.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginSanityCheck.cs
@@ -1,0 +1,10 @@
+﻿using Mediachase.Commerce.Customers;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public interface IVippsLoginSanityCheck
+    {
+        bool IsValidContact(CustomerContact contact, VippsUserInfo userInfo);
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
@@ -1,0 +1,23 @@
+﻿using EPiServer.Framework;
+using EPiServer.Framework.Initialization;
+using EPiServer.ServiceLocation;
+
+namespace Vipps.Login.Episerver.Commerce.Initialization
+{
+    [InitializableModule]
+    public class VippsLoginCommerceInitialization : IConfigurableModule
+    {
+        public void Initialize(InitializationEngine context)
+        {
+        }
+
+        public void Uninitialize(InitializationEngine context)
+        {
+        }
+
+        public void ConfigureContainer(ServiceConfigurationContext context)
+        {
+            context.Services.AddTransient<IVippsLoginCommerceService, VippsLoginCommerceService>();
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
@@ -18,6 +18,8 @@ namespace Vipps.Login.Episerver.Commerce.Initialization
         public void ConfigureContainer(ServiceConfigurationContext context)
         {
             context.Services.AddTransient<IVippsLoginCommerceService, VippsLoginCommerceService>();
+            context.Services.AddTransient<IVippsLoginMapper, VippsLoginMapper>();
+            context.Services.AddTransient<IVippsLoginDataLoader, VippsLoginDataLoader>();
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
@@ -20,6 +20,7 @@ namespace Vipps.Login.Episerver.Commerce.Initialization
             context.Services.AddTransient<IVippsLoginCommerceService, VippsLoginCommerceService>();
             context.Services.AddTransient<IVippsLoginMapper, VippsLoginMapper>();
             context.Services.AddTransient<IVippsLoginDataLoader, VippsLoginDataLoader>();
+            context.Services.AddTransient<IVippsLoginSanityCheck, VippsLoginSanityCheck>();
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -251,8 +251,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AddressExtensions.cs" />
-    <Compile Include="CustomerContactExtensions.cs" />
+    <Compile Include="Extensions\AddressExtensions.cs" />
+    <Compile Include="Extensions\CustomerContactExtensions.cs" />
     <Compile Include="Initialization\MetadataInitialization.cs" />
     <Compile Include="Initialization\VippsLoginCommerceInitialization.cs" />
     <Compile Include="IVippsLoginCommerceService.cs" />

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -258,11 +258,15 @@
     <Compile Include="Initialization\MetadataInitialization.cs" />
     <Compile Include="Initialization\VippsLoginCommerceInitialization.cs" />
     <Compile Include="IVippsLoginCommerceService.cs" />
+    <Compile Include="IVippsLoginDataLoader.cs" />
+    <Compile Include="IVippsLoginMapper.cs" />
     <Compile Include="MetadataConstants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VippsLoginCommerceService.cs" />
     <Compile Include="VippsEpiNotifications.cs" />
+    <Compile Include="VippsLoginDataLoader.cs" />
     <Compile Include="VippsLoginDuplicateAccountException.cs" />
+    <Compile Include="VippsLoginMapper.cs" />
     <Compile Include="VippsSyncOptions.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -280,5 +284,6 @@
     <None Include="packages.config" />
     <None Include="Vipps.Login.Episerver.Commerce.nuspec" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -253,6 +253,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\VippsLoginSanityCheckException.cs" />
     <Compile Include="Exceptions\VippsLoginException.cs" />
     <Compile Include="Extensions\AddressExtensions.cs" />
     <Compile Include="Extensions\CustomerContactExtensions.cs" />
@@ -261,6 +262,7 @@
     <Compile Include="IVippsLoginCommerceService.cs" />
     <Compile Include="IVippsLoginDataLoader.cs" />
     <Compile Include="IVippsLoginMapper.cs" />
+    <Compile Include="IVippsLoginSanityCheck.cs" />
     <Compile Include="MetadataConstants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VippsLoginCommerceService.cs" />
@@ -268,6 +270,7 @@
     <Compile Include="VippsLoginDataLoader.cs" />
     <Compile Include="Exceptions\VippsLoginDuplicateAccountException.cs" />
     <Compile Include="VippsLoginMapper.cs" />
+    <Compile Include="VippsLoginSanityCheck.cs" />
     <Compile Include="VippsSyncOptions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -253,6 +253,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\VippsLoginException.cs" />
     <Compile Include="Extensions\AddressExtensions.cs" />
     <Compile Include="Extensions\CustomerContactExtensions.cs" />
     <Compile Include="Initialization\MetadataInitialization.cs" />
@@ -265,7 +266,7 @@
     <Compile Include="VippsLoginCommerceService.cs" />
     <Compile Include="VippsEpiNotifications.cs" />
     <Compile Include="VippsLoginDataLoader.cs" />
-    <Compile Include="VippsLoginDuplicateAccountException.cs" />
+    <Compile Include="Exceptions\VippsLoginDuplicateAccountException.cs" />
     <Compile Include="VippsLoginMapper.cs" />
     <Compile Include="VippsSyncOptions.cs" />
   </ItemGroup>

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="VippsLoginCommerceService.cs" />
     <Compile Include="VippsEpiNotifications.cs" />
+    <Compile Include="VippsLoginDuplicateAccountException.cs" />
     <Compile Include="VippsSyncOptions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -148,11 +148,38 @@
     <Reference Include="Mediachase.WebConsoleLib, Version=12.17.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Core.12.17.1\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.JsonWebTokens.5.3.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.3.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OpenIdConnect.4.1.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -166,8 +193,14 @@
       <HintPath>..\..\packages\System.Data.SqlClient.4.4.0\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
@@ -221,8 +254,13 @@
     <Compile Include="AddressExtensions.cs" />
     <Compile Include="CustomerContactExtensions.cs" />
     <Compile Include="Initialization\MetadataInitialization.cs" />
+    <Compile Include="Initialization\VippsLoginCommerceInitialization.cs" />
+    <Compile Include="IVippsLoginCommerceService.cs" />
     <Compile Include="MetadataConstants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VippsLoginCommerceService.cs" />
+    <Compile Include="VippsEpiNotifications.cs" />
+    <Compile Include="VippsSyncOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vipps.Login.Episerver\Vipps.Login.Episerver.csproj">

--- a/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using EPiServer.Security;
+using EPiServer.ServiceLocation;
+using Mediachase.Commerce.Customers;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin.Security.Notifications;
+using Microsoft.Owin.Security.OpenIdConnect;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsEpiNotifications : VippsOpenIdConnectAuthenticationNotifications
+    {
+#pragma warning disable 649
+        private Injected<IVippsLoginService> _vippsLoginService;
+        private Injected<VippsLoginCommerceService> _vippsCommerceService;
+        private Injected<MapUserKey> _mapUserKey;
+#pragma warning restore 649
+
+        public VippsEpiNotifications()
+        {
+            SecurityTokenValidated = DefaultSecurityTokenValidated;
+        }
+
+        private async Task DefaultSecurityTokenValidated(
+            SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> context
+        )
+        {
+            // Prevent redirecting to external Uris
+            var redirectUri = new Uri(context.AuthenticationTicket.Properties.RedirectUri,
+                UriKind.RelativeOrAbsolute);
+            if (redirectUri.IsAbsoluteUri)
+            {
+                context.AuthenticationTicket.Properties.RedirectUri = redirectUri.PathAndQuery;
+            }
+
+            var identity = context.AuthenticationTicket.Identity;
+            var vippsInfo = _vippsLoginService.Service.GetVippsUserInfo(identity);
+
+            // First check if we already have a contact for this sub
+            var emailAddress = FindBySubjectGuid(vippsInfo?.Sub);
+            if (string.IsNullOrWhiteSpace(emailAddress))
+            {
+                // Try to find contact by vipps email/phone number
+                var contacts = FindByVippsInfo(vippsInfo).ToArray();
+                if (contacts.Length == 1)
+                {
+                    // TODO: implement 'Sanity check'
+                    emailAddress = GetLoginEmailFromContact(contacts.First());
+                }
+                else if (contacts.Length > 1)
+                {
+                    throw new OpenIdConnectProtocolException(
+                        "Multiple accounts found matching your Vipps info."
+                    );
+                }
+            }
+
+            // New user
+            if (string.IsNullOrWhiteSpace(emailAddress))
+            {
+                emailAddress = identity.FindFirst(ClaimTypes.Email)?.Value;
+            }
+
+            // By default we use email address as username
+            if (!identity.HasClaim(x => x.Type.Equals(identity.NameClaimType)))
+            {
+                identity.AddClaim(
+                    new Claim(identity.NameClaimType, emailAddress)
+                );
+            }
+
+            // Sync user and the roles to Epi
+            await ServiceLocator.Current.GetInstance<ISynchronizingUserService>()
+                .SynchronizeAsync(identity, new List<string>());
+        }
+
+        private IEnumerable<CustomerContact> FindByVippsInfo(VippsUserInfo vippsInfo)
+        {
+            return _vippsCommerceService.Service.FindCustomerContacts(vippsInfo.Email, vippsInfo.PhoneNumber);
+        }
+
+        protected virtual string FindBySubjectGuid(Guid? subjectGuid)
+        {
+            if (!subjectGuid.HasValue)
+            {
+                return null;
+            }
+
+            var customerContact = _vippsCommerceService.Service
+                .FindCustomerContacts(subjectGuid.Value)
+                .FirstOrDefault();
+            if (customerContact == null)
+            {
+                return null;
+            }
+
+            return GetLoginEmailFromContact(customerContact);
+        }
+
+        private string GetLoginEmailFromContact(CustomerContact customerContact)
+        {
+            var something = _mapUserKey.Service.ToUserKey(customerContact.UserId);
+            return something.ToString();
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
@@ -93,20 +93,13 @@ namespace Vipps.Login.Episerver.Commerce
             }
 
             var customerContact = _vippsCommerceService.Service
-                .FindCustomerContacts(subjectGuid.Value)
-                .FirstOrDefault();
-            if (customerContact == null)
-            {
-                return null;
-            }
-
-            return GetLoginEmailFromContact(customerContact);
+                .FindCustomerContact(subjectGuid.Value);
+            return customerContact == null ? null : GetLoginEmailFromContact(customerContact);
         }
 
         private string GetLoginEmailFromContact(CustomerContact customerContact)
         {
-            var something = _mapUserKey.Service.ToUserKey(customerContact.UserId);
-            return something.ToString();
+            return _mapUserKey.Service.ToUserKey(customerContact?.UserId)?.ToString();
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsEpiNotifications.cs
@@ -55,8 +55,8 @@ namespace Vipps.Login.Episerver.Commerce
                 }
                 else if (contacts.Length > 1)
                 {
-                    throw new OpenIdConnectProtocolException(
-                        "Multiple accounts found matching your Vipps info."
+                    throw new VippsLoginDuplicateAccountException(
+                        "Multiple accounts found matching your Vipps info. Please log in and link your account through your profile page."
                     );
                 }
             }

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Principal;
+using Mediachase.BusinessFoundation.Data;
+using Mediachase.BusinessFoundation.Data.Business;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsLoginCommerceService : IVippsLoginCommerceService
+    {
+        private readonly IVippsLoginService _vippsLoginService;
+
+        public VippsLoginCommerceService(
+            IVippsLoginService vippsLoginService)
+        {
+            _vippsLoginService = vippsLoginService;
+        }
+
+        public IEnumerable<CustomerContact> FindCustomerContacts(Guid subjectGuid)
+        {
+            return BusinessManager
+                .List(ContactEntity.ClassName, new[]
+                {
+                    new FilterElement(
+                        MetadataConstants.VippsSubjectGuidFieldName,
+                        FilterElementType.Equal,
+                        subjectGuid
+                    )
+                })
+                .OfType<CustomerContact>();
+        }
+
+        public IEnumerable<CustomerContact> FindCustomerContacts(string email, string phone)
+        {
+            //TODO: search on phone number
+            return BusinessManager
+                .List(ContactEntity.ClassName, new[]
+                {
+                    new FilterElement(
+                        "Email",
+                        FilterElementType.Equal,
+                        email
+                    )
+                })
+                .OfType<CustomerContact>();
+        }
+
+        public void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default)
+        {
+            if (identity == null)
+                throw new ArgumentNullException(nameof(identity));
+            if (currentContact == null)
+                throw new ArgumentNullException(nameof(currentContact));
+            if (options == null)
+                options = new VippsSyncOptions();
+
+            var vippsUserInfo = _vippsLoginService.GetVippsUserInfo(identity);
+            if (vippsUserInfo == null)
+            {
+                return;
+            }
+
+            // Always sync vipps subject guid
+            currentContact.SetVippsSubject(vippsUserInfo.Sub);
+            if (options.SyncContactInfo)
+            {
+                // Maps fields onto customer contact
+                // Vipps email, firstname, lastname, fullname, birthdate
+                MapVippsContactFields(currentContact, vippsUserInfo);
+            }
+
+            if (options.SyncAddresses)
+            {
+                SyncAddresses(identity, currentContact, options.AddressType);
+            }
+
+            currentContact.SaveChanges();
+        }
+
+        protected virtual void SyncAddresses(
+            IIdentity identity,
+            CustomerContact currentContact,
+            CustomerAddressTypeEnum addressType)
+        {
+            if (identity == null)
+                throw new ArgumentNullException(nameof(identity));
+            if (currentContact == null)
+                throw new ArgumentNullException(nameof(currentContact));
+
+            var vippsUserInfo = _vippsLoginService.GetVippsUserInfo(identity);
+            if (vippsUserInfo == null)
+            {
+                return;
+            }
+
+            foreach (var vippsAddress in vippsUserInfo.Addresses)
+            {
+                // Vipps addresses don't have an ID
+                // They can be identified by Vipps address type
+                var address =
+                    currentContact.ContactAddresses.FindVippsAddress(vippsAddress.AddressType);
+                var isNewAddress = address == null;
+                if (isNewAddress)
+                {
+                    address = CustomerAddress.CreateInstance();
+                    address.AddressType = addressType;
+                }
+
+                // Maps fields onto customer address:
+                // Vipps address type, street, city, postalcode, countrycode
+                MapVippsAddressFields(address, vippsAddress);
+                address.DaytimePhoneNumber = address.EveningPhoneNumber = vippsUserInfo.PhoneNumber;
+
+                if (isNewAddress)
+                {
+                    currentContact.AddContactAddress(address);
+                }
+                else
+                {
+                    currentContact.UpdateContactAddress(address);
+                }
+            }
+        }
+
+        protected virtual void MapVippsContactFields(
+            CustomerContact contact,
+            VippsUserInfo userInfo
+        )
+        {
+            if (userInfo == null) throw new ArgumentNullException(nameof(userInfo));
+
+            contact.Email = userInfo.Email;
+            contact.FirstName = userInfo.GivenName;
+            contact.LastName = userInfo.FamilyName;
+            contact.FullName = userInfo.Name;
+            contact.BirthDate = userInfo.BirthDate;
+        }
+
+        protected virtual void MapVippsAddressFields(
+            CustomerAddress address,
+            VippsAddress vippsAddress
+        )
+        {
+            if (vippsAddress == null) throw new ArgumentNullException(nameof(vippsAddress));
+
+            address.Name = $"Vipps - {address.GetVippsAddressType()}";
+            address.Line1 = vippsAddress.StreetAddress;
+            address.City = vippsAddress.Region;
+            address.PostalCode = vippsAddress.PostalCode;
+            //TODO: map country code
+            address.CountryCode = vippsAddress.Country;
+            address.SetVippsAddressType(vippsAddress.AddressType);
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
@@ -83,7 +83,7 @@ namespace Vipps.Login.Episerver.Commerce
                 _vippsLoginMapper.MapVippsContactFields(currentContact, vippsUserInfo);
             }
 
-            if (options.SyncAddresses)
+            if (options.SyncAddresses && vippsUserInfo.Addresses != null)
             {
                 foreach (var vippsAddress in vippsUserInfo.Addresses)
                 {

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
@@ -5,6 +5,7 @@ using System.Security.Principal;
 using Mediachase.BusinessFoundation.Data;
 using Mediachase.BusinessFoundation.Data.Business;
 using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Extensions;
 using Vipps.Login.Models;
 
 namespace Vipps.Login.Episerver.Commerce

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginDataLoader.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginDataLoader.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EPiServer.Logging;
+using Mediachase.BusinessFoundation.Data;
+using Mediachase.BusinessFoundation.Data.Business;
+using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsLoginDataLoader : IVippsLoginDataLoader
+    {
+        private readonly MapUserKey _mapUserKey;
+
+        private static readonly ILogger Logger = LogManager.GetLogger(typeof(VippsLoginDataLoader));
+
+        public VippsLoginDataLoader(MapUserKey mapUserKey)
+        {
+            _mapUserKey = mapUserKey;
+        }
+
+        public virtual IEnumerable<CustomerContact> FindContactsBySubjectGuid(Guid subjectGuid)
+        {
+            try
+            {
+                return BusinessManager
+                    .List(ContactEntity.ClassName, new[]
+                    {
+                        new FilterElement(
+                            MetadataConstants.VippsSubjectGuidFieldName,
+                            FilterElementType.Equal,
+                            subjectGuid
+                        )
+                    })
+                    .OfType<CustomerContact>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Vipps.Login: could not load contacts by subjectGuid", ex);
+                return Enumerable.Empty<CustomerContact>();
+            }
+        }
+
+        public virtual IEnumerable<CustomerContact> FindContactsByEmail(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                Logger.Warning("Vipps.Login: could not load contacts for empty email");
+                return Enumerable.Empty<CustomerContact>();
+            }
+
+            IEnumerable<CustomerContact> byEmail;
+            try
+            {
+                byEmail = BusinessManager
+                    .List(ContactEntity.ClassName, new[]
+                    {
+                        new FilterElement(
+                            ContactEntity.FieldEmail,
+                            FilterElementType.Equal,
+                            email
+                        )
+                    }, new SortingElement[0], 0, 2)
+                    .OfType<CustomerContact>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Vipps.Login: could not load contacts by email", ex);
+                byEmail = Enumerable.Empty<CustomerContact>();
+            }
+
+            var byUserKey = CustomerContext.Current.GetContactByUserId(_mapUserKey.ToTypedString(email));
+            if (byUserKey != null)
+            {
+                return new[] {byUserKey}
+                    .Union(byEmail);
+            }
+
+            return byEmail;
+        }
+
+        public virtual IEnumerable<CustomerContact> FindContactsByPhone(string phone)
+        {
+            if (string.IsNullOrWhiteSpace(phone))
+            {
+                Logger.Warning("Vipps.Login: could not load contacts for empty phone number");
+                return Enumerable.Empty<CustomerContact>();
+            }
+            try
+            {
+                return BusinessManager
+                    .List(AddressEntity.ClassName, new FilterElement[]
+                    {
+                        new OrBlockFilterElement(
+                            new FilterElement(
+                                AddressEntity.FieldDaytimePhoneNumber,
+                                FilterElementType.Equal,
+                                phone
+                            ),
+                            new FilterElement(
+                                AddressEntity.FieldEveningPhoneNumber,
+                                FilterElementType.Equal,
+                                phone
+                            ))
+                    }, new SortingElement[0], 0, 50)
+                    .OfType<CustomerAddress>()
+                    .Where(x => x.ContactId.HasValue)
+                    .Select(x => x.ContactId.Value)
+                    .GroupBy(x => x)
+                    .Select(x => BusinessManager.Load(ContactEntity.ClassName, x.First()))
+                    .OfType<CustomerContact>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Vipps.Login: could not load contacts by phone number", ex);
+                return Enumerable.Empty<CustomerContact>();
+            }
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginDuplicateAccountException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginDuplicateAccountException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsLoginDuplicateAccountException : Exception
+    {
+        public VippsLoginDuplicateAccountException(string message)
+              : base(message)
+        {
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
@@ -46,8 +46,7 @@ namespace Vipps.Login.Episerver.Commerce
             address.Line1 = vippsAddress.StreetAddress;
             address.City = vippsAddress.Region;
             address.PostalCode = vippsAddress.PostalCode;
-            //TODO: map country code
-            address.CountryCode = vippsAddress.Country;
+            address.CountryCode = ToEpiCountryCode(vippsAddress.Country);
             address.SetVippsAddressType(vippsAddress.AddressType);
         }
 
@@ -86,6 +85,18 @@ namespace Vipps.Login.Episerver.Commerce
             {
                 currentContact.UpdateContactAddress(address);
             }
+        }
+
+        protected virtual string ToEpiCountryCode(string vippsCountryCode)
+        {
+            // Map country code to epi country code (three letter)
+            // As only Norwegian addresses are supported, decided to keep it simple
+            if (vippsCountryCode.Equals("no", StringComparison.InvariantCultureIgnoreCase))
+            {
+                return "NOR";
+            }
+
+            return vippsCountryCode;
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Extensions;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsLoginMapper : IVippsLoginMapper
+    {
+
+        public virtual void MapVippsContactFields(
+            CustomerContact contact,
+            VippsUserInfo userInfo
+        )
+        {
+            if (contact == null) throw new ArgumentNullException(nameof(contact));
+            if (userInfo == null) throw new ArgumentNullException(nameof(userInfo));
+
+            contact.Email = userInfo.Email;
+            contact.FirstName = userInfo.GivenName;
+            contact.LastName = userInfo.FamilyName;
+            contact.FullName = userInfo.Name;
+            contact.BirthDate = userInfo.BirthDate;
+        }
+
+        public virtual void MapVippsAddressFields(
+            CustomerAddress address,
+            VippsAddress vippsAddress
+        )
+        {
+            if (address == null) throw new ArgumentNullException(nameof(address));
+            if (vippsAddress == null) throw new ArgumentNullException(nameof(vippsAddress));
+
+            address.Name = $"Vipps - {address.GetVippsAddressType()}";
+            address.Line1 = vippsAddress.StreetAddress;
+            address.City = vippsAddress.Region;
+            address.PostalCode = vippsAddress.PostalCode;
+            //TODO: map country code
+            address.CountryCode = vippsAddress.Country;
+            address.SetVippsAddressType(vippsAddress.AddressType);
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginMapper.cs
@@ -28,7 +28,7 @@ namespace Vipps.Login.Episerver.Commerce
             {
                 contact.FullName = userInfo.Name;
             }
-            if (userInfo.BirthDate.HasValue)
+            if (userInfo.BirthDate.HasValue && userInfo.BirthDate.Value > DateTime.MinValue)
             {
                 contact.BirthDate = userInfo.BirthDate;
             }

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginSanityCheck.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginSanityCheck.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Models;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsLoginSanityCheck : IVippsLoginSanityCheck
+    {
+        public bool IsValidContact(CustomerContact contact, VippsUserInfo userInfo)
+        {
+            if (contact == null || userInfo == null)
+            {
+                return false;
+            }
+
+            return
+                (userInfo.GivenName ?? string.Empty).Equals(contact.FirstName, StringComparison.InvariantCultureIgnoreCase) &&
+                (userInfo.FamilyName ?? string.Empty).Equals(contact.LastName, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsSyncOptions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsSyncOptions.cs
@@ -1,0 +1,13 @@
+﻿using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsSyncOptions
+    {
+        public bool SyncContactInfo { get; set; } = true;
+        public bool SyncAddresses { get; set; } = true;
+
+        public CustomerAddressTypeEnum AddressType { get; set; } =
+            CustomerAddressTypeEnum.Shipping | CustomerAddressTypeEnum.Billing;
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsSyncOptions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsSyncOptions.cs
@@ -6,6 +6,7 @@ namespace Vipps.Login.Episerver.Commerce
     {
         public bool SyncContactInfo { get; set; } = true;
         public bool SyncAddresses { get; set; } = true;
+        public bool ShouldSaveContact { get; set; } = true;
 
         public CustomerAddressTypeEnum AddressType { get; set; } =
             CustomerAddressTypeEnum.Shipping | CustomerAddressTypeEnum.Billing;

--- a/src/Vipps.Login.Episerver.Commerce/packages.config
+++ b/src/Vipps.Login.Episerver.Commerce/packages.config
@@ -12,12 +12,22 @@
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
+  <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net472" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net472" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net472" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net472" />

--- a/src/Vipps.Login.Episerver/Vipps.Login.Episerver.csproj
+++ b/src/Vipps.Login.Episerver/Vipps.Login.Episerver.csproj
@@ -147,7 +147,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VippsLoginInitialization.cs" />
+    <Compile Include="VippsLoginEpiserverInitialization.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Vipps.Login\Vipps.Login.csproj">

--- a/src/Vipps.Login.Episerver/Vipps.Login.Episerver.csproj
+++ b/src/Vipps.Login.Episerver/Vipps.Login.Episerver.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">

--- a/src/Vipps.Login.Episerver/VippsLoginEpiserverInitialization.cs
+++ b/src/Vipps.Login.Episerver/VippsLoginEpiserverInitialization.cs
@@ -5,7 +5,7 @@ using EPiServer.ServiceLocation;
 namespace Vipps.Login.Episerver
 {
     [InitializableModule]
-    public class VippsLoginInitialization : IConfigurableModule
+    public class VippsLoginEpiserverInitialization : IConfigurableModule
     {
         public void Initialize(InitializationEngine context)
         {

--- a/src/Vipps.Login/Vipps.Login.csproj
+++ b/src/Vipps.Login/Vipps.Login.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="IdentityModel, Version=4.1.0.0, Culture=neutral, PublicKeyToken=e7877f4675df049f, processorArchitecture=MSIL">

--- a/src/Vipps.Login/VippsOpenIdConnectAuthenticationNotifications.cs
+++ b/src/Vipps.Login/VippsOpenIdConnectAuthenticationNotifications.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using IdentityModel.Client;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -24,7 +26,6 @@ namespace Vipps.Login
             AuthorizationCodeReceived = DefaultAuthorizationCodeReceived;
             AuthenticationFailed = DefaultAuthenticationFailed;
         }
-
         protected virtual Task DefaultRedirectToIdentityProvider(RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> context)
         {
             // In order to support multi site we change the return uri based on the current request

--- a/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
@@ -115,40 +115,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             Assert.Equal(VippsAddressType.Home, customerAddress.GetVippsAddressType());
         }
 
-        [Fact]
-        public void MapVippsAddressThrowsIfNull()
-        {
-            var customerAddress = CustomerAddress.CreateInstance();
-
-            Assert.Throws<ArgumentNullException>(() => customerAddress.MapVippsAddress(null));
-        }
-
-        [Fact]
-        public void MapVippsAddress()
-        {
-            var customerAddress = CustomerAddress.CreateInstance();
-
-            var vippsAddressType = VippsAddressType.Work;
-            var vippsStreetAddress = "Vipps Street Address";
-            var region = "Oslo";
-            var country = "NO";
-            var postalCode = "0151";
-
-            customerAddress.MapVippsAddress(new VippsAddress
-            {
-                AddressType = vippsAddressType,
-                StreetAddress = vippsStreetAddress,
-                Region = region,
-                Country = country,
-                PostalCode = postalCode
-            });
-
-            Assert.Equal(vippsAddressType, customerAddress.GetVippsAddressType());
-            Assert.Equal(vippsStreetAddress, customerAddress.Line1);
-            Assert.Equal(region, customerAddress.City);
-            Assert.Equal(country, customerAddress.CountryCode);
-            Assert.Equal(postalCode, customerAddress.PostalCode);
-        }
+       
         private CustomerAddress CreateVippsAddress(VippsAddressType addressType)
         {
             var vippsAddress = CustomerAddress.CreateInstance();

--- a/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
@@ -122,6 +122,5 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             vippsAddress.SetVippsAddressType(addressType);
             return vippsAddress;
         }
-
     }
 }

--- a/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/AddressExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Extensions;
 using Vipps.Login.Models;
 using Xunit;
 

--- a/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Extensions;
 using Vipps.Login.Models;
 using Xunit;
 

--- a/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
@@ -43,43 +43,5 @@ namespace Vipps.Login.Episerver.Commerce.Tests
 
             Assert.Equal(guid, contact.GetVippsSubject());
         }
-
-        [Fact]
-        public void MapVippsUserInfoThrowsIfNull()
-        {
-            var contact = CustomerContact.CreateInstance();
-
-            Assert.Throws<ArgumentNullException>(() => contact.MapVippsUserInfo(null));
-        }
-
-        [Fact]
-        public void MapVippsUserInfo()
-        {
-            var contact = CustomerContact.CreateInstance();
-
-            var subject = Guid.NewGuid();
-            var email = "test@geta.no";
-            var givenName = "Test";
-            var familyName = "Tester";
-            var fullName = "Test Tester";
-            var birthDate = DateTime.Now;
-
-            contact.MapVippsUserInfo(new VippsUserInfo
-            {
-                Sub = subject,
-                Email = email,
-                GivenName = givenName,
-                FamilyName = familyName,
-                Name = fullName,
-                BirthDate = birthDate
-            });
-
-            Assert.Equal(subject, contact.GetVippsSubject());
-            Assert.Equal(email, contact.Email);
-            Assert.Equal(givenName, contact.FirstName);
-            Assert.Equal(familyName, contact.LastName);
-            Assert.Equal(fullName, contact.FullName);
-            Assert.Equal(birthDate, contact.BirthDate);
-        }
     }
 }

--- a/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/CustomerContactExtensionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Mediachase.Commerce.Customers;
 using Vipps.Login.Episerver.Commerce.Extensions;
-using Vipps.Login.Models;
 using Xunit;
 
 namespace Vipps.Login.Episerver.Commerce.Tests

--- a/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
@@ -277,6 +277,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AddressExtensionsTests.cs" />
     <Compile Include="VippsEpiNotificationsTests.cs" />
+    <Compile Include="VippsLoginCommerceServiceTests.cs" />
     <Compile Include="VippsLoginMapperTests.cs" />
     <Compile Include="VippsLoginSanityCheckTests.cs" />
   </ItemGroup>

--- a/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
@@ -157,11 +157,38 @@
     <Reference Include="Mediachase.WebConsoleLib, Version=12.17.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPiServer.Commerce.Core.12.17.1\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.JsonWebTokens.5.3.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Tokens.5.3.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OpenIdConnect.4.1.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -175,8 +202,14 @@
       <HintPath>..\..\packages\System.Data.SqlClient.4.4.0\lib\net461\System.Data.SqlClient.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
@@ -243,6 +276,8 @@
     <Compile Include="CustomerContactExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AddressExtensionsTests.cs" />
+    <Compile Include="VippsEpiNotificationsTests.cs" />
+    <Compile Include="VippsLoginMapperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">

--- a/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
@@ -278,6 +278,7 @@
     <Compile Include="AddressExtensionsTests.cs" />
     <Compile Include="VippsEpiNotificationsTests.cs" />
     <Compile Include="VippsLoginMapperTests.cs" />
+    <Compile Include="VippsLoginSanityCheckTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsEpiNotificationsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsEpiNotificationsTests.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using EPiServer.Security;
+using FakeItEasy;
+using Mediachase.Commerce.Customers;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Notifications;
+using Microsoft.Owin.Security.OpenIdConnect;
+using Vipps.Login.Episerver.Commerce.Exceptions;
+using Vipps.Login.Models;
+using Xunit;
+
+namespace Vipps.Login.Episerver.Commerce.Tests
+{
+    public class VippsEpiNotificationsTests
+    {
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedThrowsIfUserInfoIsNull()
+        {
+            var vippsLoginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => vippsLoginService.GetVippsUserInfo(A<ClaimsIdentity>._)).Returns(null);
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                vippsLoginService,
+                A.Fake<IVippsLoginCommerceService>(),
+                A.Fake<MapUserKey>()
+            );
+            
+            await Assert.ThrowsAsync<VippsLoginException>(async () =>
+                await notifications.DefaultSecurityTokenValidated(CreateContext()));
+        }
+
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedRewritesRedirectUriToLocal()
+        {
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginCommerceService>(),
+                A.Fake<MapUserKey>()
+            );
+
+            var context = CreateContext();
+            await notifications.DefaultSecurityTokenValidated(context);
+
+            Assert.Equal("/redirect-url", context.AuthenticationTicket.Properties.RedirectUri);
+        }
+
+        // New user
+        // No contact with subject guid
+        // No contact with phone or by email
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedSetsVippsEmailAsNameClaim()
+        {
+            var testEmail = "test@test.com";
+            var testPhoneNumber = "0612345678";
+
+            var vippsLoginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => vippsLoginService.GetVippsUserInfo(A<ClaimsIdentity>._))
+                .Returns(new VippsUserInfo
+                {
+                    Email = testEmail,
+                    PhoneNumber = testPhoneNumber
+                });
+            
+            // No contact with subject guid
+            var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
+            A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
+                .Returns(null);
+
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                vippsLoginService,
+                vippsCommerceService,
+                GetMapUserKey(testEmail)
+            );
+
+            var context = CreateContext();
+
+            await notifications.DefaultSecurityTokenValidated(context);
+            Assert.True(
+                context.AuthenticationTicket.Identity.HasClaim(
+                    context.AuthenticationTicket.Identity.NameClaimType,
+                    testEmail)
+            );
+        }
+
+        // Existing user
+        // Find contact with matching subject guid
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedSetsEmailAsNameClaim()
+        {
+            var testEmail = "test@test.com";
+            var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
+            A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
+                .Returns(new CustomerContact() {UserId = testEmail});
+           
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                A.Fake<IVippsLoginService>(),
+                vippsCommerceService,
+                GetMapUserKey(testEmail)
+            );
+
+            var context = CreateContext();
+
+            await notifications.DefaultSecurityTokenValidated(context);
+            Assert.True(
+                context.AuthenticationTicket.Identity.HasClaim(
+                    context.AuthenticationTicket.Identity.NameClaimType,
+                    testEmail)
+            );
+        }
+
+        // Existing user
+        // No contact with subject guid
+        // Find with phone or by email
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedSetsFirstCustomerAsNameClaim()
+        {
+            var testEmail = "test@test.com";
+            var testPhoneNumber = "0612345678";
+
+            var vippsLoginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => vippsLoginService.GetVippsUserInfo(A<ClaimsIdentity>._))
+                .Returns(new VippsUserInfo
+                {
+                    Email = testEmail,
+                    PhoneNumber = testPhoneNumber
+                });
+
+            // No contact with subject guid
+            var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
+            A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
+                .Returns(null);
+
+            // Find with phone or by email
+            A.CallTo(() => vippsCommerceService.FindCustomerContacts(testEmail, testPhoneNumber))
+                .Returns(new [] { new CustomerContact { UserId = testEmail } });
+
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                vippsLoginService,
+                vippsCommerceService,
+                GetMapUserKey(testEmail)
+            );
+
+            var context = CreateContext();
+
+            await notifications.DefaultSecurityTokenValidated(context);
+            Assert.True(
+                context.AuthenticationTicket.Identity.HasClaim(
+                    context.AuthenticationTicket.Identity.NameClaimType,
+                    testEmail)
+            );
+        }
+
+        // Existing users
+        // No contact with subject guid
+        // Find multiple with phone or by email
+        [Fact]
+        public async Task DefaultSecurityTokenValidatedThrowsIfMultipleContactsFound()
+        {
+            var testEmail = "test@test.com";
+            var testPhoneNumber = "0612345678";
+
+            var vippsLoginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => vippsLoginService.GetVippsUserInfo(A<ClaimsIdentity>._))
+                .Returns(new VippsUserInfo
+                {
+                    Email = testEmail,
+                    PhoneNumber = testPhoneNumber
+                });
+
+            // No contact with subject guid
+            var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
+            A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
+                .Returns(null);
+
+            // Find multiple with phone or by email
+            A.CallTo(() => vippsCommerceService.FindCustomerContacts(testEmail, testPhoneNumber))
+                .Returns(new[] { new CustomerContact() { UserId = testEmail }, new CustomerContact() { UserId = $"{testEmail}1" } });
+
+            var notifications = new VippsEpiNotifications(
+                A.Fake<ISynchronizingUserService>(),
+                vippsLoginService,
+                vippsCommerceService,
+                GetMapUserKey(testEmail)
+            );
+
+            var context = CreateContext();
+
+            await Assert.ThrowsAsync<VippsLoginDuplicateAccountException>(async () =>
+                await notifications.DefaultSecurityTokenValidated(context));
+        }
+
+        private SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> CreateContext()
+        {
+            var options =
+                new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority");
+            var context =
+                new SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(
+                    A.Fake<IOwinContext>(), options)
+                {
+                    AuthenticationTicket = new AuthenticationTicket(new ClaimsIdentity(), new AuthenticationProperties(
+                        new Dictionary<string, string>()
+                            {{".redirect", "https://test.url/redirect-url"}}))
+                };
+            return context;
+        }
+
+        private MapUserKey GetMapUserKey(string testEmail)
+        {
+            var mapUserKey = A.Fake<MapUserKey>();
+            A.CallTo(() => mapUserKey.ToUserKey(testEmail)).Returns(testEmail);
+            return mapUserKey;
+        }
+    }
+}

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using EPiServer.Events.ChangeNotification.Implementation;
+using EPiServer.Security;
+using FakeItEasy;
+using Mediachase.BusinessFoundation.Data;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Exceptions;
+using Vipps.Login.Models;
+using Xunit;
+
+namespace Vipps.Login.Episerver.Commerce.Tests
+{
+    public class VippsLoginCommerceServiceTests
+    {
+        [Fact]
+        public void FindCustomerContactShouldBeNull()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>());
+
+            var contact = service.FindCustomerContact(Guid.Empty);
+            Assert.Null(contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactShouldReturnContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsBySubjectGuid(A<Guid>._))
+                .Returns(new[] {expectedContact});
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContact(Guid.Empty);
+            Assert.Equal(expectedContact, contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactShouldReturnFirstContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsBySubjectGuid(A<Guid>._))
+                .Returns(new[] {expectedContact, new CustomerContact()});
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContact(Guid.Empty);
+            Assert.Equal(expectedContact, contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactShouldReturnNotEqualLastContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsBySubjectGuid(A<Guid>._))
+                .Returns(new[] {new CustomerContact(), expectedContact});
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContact(Guid.Empty);
+            Assert.NotEqual(expectedContact, contact);
+        }
+
+
+        [Fact]
+        public void FindCustomerContactsShouldBeEmpty()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>());
+
+            var contact = service.FindCustomerContacts(string.Empty, string.Empty);
+            Assert.Empty(contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactsShouldReturnByEmail()
+        {
+            var expectedContacts = new[]
+            {
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(1)},
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(2)}
+            };
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByEmail(A<string>._))
+                .Returns(expectedContacts);
+
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader);
+
+            var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
+
+            Assert.Equal(expectedContacts, contacts);
+        }
+
+        [Fact]
+        public void FindCustomerContactsShouldReturnByPhone()
+        {
+            var expectedContacts = new[]
+            {
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(1)},
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(2)}
+            };
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByPhone(A<string>._))
+                .Returns(expectedContacts);
+
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader);
+
+            var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
+
+            Assert.Equal(expectedContacts, contacts);
+        }
+
+        [Fact]
+        public void FindCustomerContactsShouldBeDistinct()
+        {
+            var expectedContacts = new[]
+            {
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(1)},
+                new CustomerContact {PrimaryKeyId = new PrimaryKeyId(2)}
+            };
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByEmail(A<string>._))
+                .Returns(expectedContacts);
+            A.CallTo(() => dataLoader.FindContactsByPhone(A<string>._))
+                .Returns(expectedContacts);
+
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader);
+
+            var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
+
+            Assert.Equal(expectedContacts, contacts);
+        }
+
+        [Fact]
+        public void SyncInfoShouldThrowOnNull()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>());
+
+            Assert.Throws<ArgumentNullException>(() => service.SyncInfo(null, null));
+            Assert.Throws<ArgumentNullException>(() => service.SyncInfo(new ClaimsIdentity(), null));
+            Assert.Throws<ArgumentNullException>(() => service.SyncInfo(null, new CustomerContact()));
+        }
+
+        [Fact]
+        public void SyncInfoShouldSyncUserInfo()
+        {
+            var customerContact = A.Fake<CustomerContact>();
+            var userinfo = new VippsUserInfo()
+            {
+                Addresses = Enumerable.Empty<VippsAddress>()
+            };
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.GetVippsUserInfo(A<ClaimsIdentity>._)).Returns(userinfo);
+            var mapper = A.Fake<IVippsLoginMapper>();
+            var service = new VippsLoginCommerceService(
+                loginService,
+                mapper,
+                A.Fake<IVippsLoginDataLoader>());
+
+            service.SyncInfo(new ClaimsIdentity(), customerContact, new VippsSyncOptions
+            {
+                SyncContactInfo = true,
+                SyncAddresses = false,
+                ShouldSaveContact = false,
+            });
+
+            A.CallTo(() => mapper.MapVippsContactFields(A<CustomerContact>._, A<VippsUserInfo>._)).MustHaveHappened();
+        }
+
+        [Fact]
+        public void SyncInfoShouldNotSyncUserInfo()
+        {
+            var userinfo = new VippsUserInfo()
+            {
+                Addresses = Enumerable.Empty<VippsAddress>()
+            };
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.GetVippsUserInfo(A<ClaimsIdentity>._)).Returns(userinfo);
+            var mapper = A.Fake<IVippsLoginMapper>();
+            var service = new VippsLoginCommerceService(
+                loginService,
+                mapper,
+                A.Fake<IVippsLoginDataLoader>());
+
+            service.SyncInfo(new ClaimsIdentity(), new CustomerContact(), new VippsSyncOptions
+            {
+                SyncContactInfo = false,
+                SyncAddresses = false,
+                ShouldSaveContact = false,
+            });
+
+            A.CallTo(() => mapper.MapVippsAddressFields(A<CustomerAddress>._, A<VippsAddress>._)).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public void SyncInfoShouldSyncAddressInfo()
+        {
+            var contact = A.Fake<CustomerContact>();
+
+            var userInfo = new VippsUserInfo()
+            {
+                Sub = Guid.NewGuid(),
+                Addresses = new[] {new VippsAddress(), new VippsAddress() }
+            };
+            var identity = new ClaimsIdentity();
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.GetVippsUserInfo(A<IIdentity>._))
+                .Returns(userInfo);
+
+            var mapper = A.Fake<IVippsLoginMapper>();
+            var service = new VippsLoginCommerceService(
+                loginService,
+                mapper,
+                A.Fake<IVippsLoginDataLoader>());
+
+            service.SyncInfo(identity, contact, new VippsSyncOptions
+            {
+                SyncContactInfo = false,
+                SyncAddresses = true,
+                ShouldSaveContact = false,
+            });
+
+            A.CallTo(() => mapper.MapAddress(null, CustomerAddressTypeEnum.Billing, null, String.Empty))
+                .WithAnyArguments()
+                .MustHaveHappenedTwiceExactly();
+        }
+    }
+}

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginMapperTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginMapperTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Episerver.Commerce.Extensions;
+using Vipps.Login.Models;
+using Xunit;
+
+namespace Vipps.Login.Episerver.Commerce.Tests
+{
+    public class VippsLoginMapperTests
+    {
+        [Fact]
+        public void MapVippsContactFieldsThrowsIfVippsInfoIsNull()
+        {
+            var mapper = new VippsLoginMapper();
+
+            var contact = CustomerContact.CreateInstance();
+
+            Assert.Throws<ArgumentNullException>(() => mapper.MapVippsContactFields(contact, null));
+        }
+
+        [Fact]
+        public void MapVippsContactFieldsThrowsIfContactIsNull()
+        {
+            var mapper = new VippsLoginMapper();
+
+
+            Assert.Throws<ArgumentNullException>(() => mapper.MapVippsContactFields(null, new VippsUserInfo()));
+        }
+
+        [Fact]
+        public void MapVippsContactFields()
+        {
+            var mapper = new VippsLoginMapper();
+
+            var contact = CustomerContact.CreateInstance();
+
+            var subject = Guid.NewGuid();
+            var email = "test@geta.no";
+            var givenName = "Test";
+            var familyName = "Tester";
+            var fullName = "Test Tester";
+            var birthDate = DateTime.Now;
+
+            mapper.MapVippsContactFields(contact, new VippsUserInfo
+            {
+                Sub = subject,
+                Email = email,
+                GivenName = givenName,
+                FamilyName = familyName,
+                Name = fullName,
+                BirthDate = birthDate
+            });
+
+            Assert.Equal(email, contact.Email);
+            Assert.Equal(givenName, contact.FirstName);
+            Assert.Equal(familyName, contact.LastName);
+            Assert.Equal(fullName, contact.FullName);
+            Assert.Equal(birthDate, contact.BirthDate);
+        }
+
+        [Fact]
+        public void MapVippsAddressFieldsThrowsIfVippsInfoIsNull()
+        {
+            var mapper = new VippsLoginMapper();
+
+            var customerAddress = CustomerAddress.CreateInstance();
+
+            Assert.Throws<ArgumentNullException>(() => mapper.MapVippsAddressFields(customerAddress, null));
+        }
+
+        [Fact]
+        public void MapVippsAddressFieldsThrowsIfAddressIsNull()
+        {
+            var mapper = new VippsLoginMapper();
+
+            Assert.Throws<ArgumentNullException>(() => mapper.MapVippsAddressFields(null, new VippsAddress()));
+        }
+
+        [Fact]
+        public void MapVippsAddress()
+        {
+            var mapper = new VippsLoginMapper();
+
+            var customerAddress = CustomerAddress.CreateInstance();
+
+            var vippsAddressType = VippsAddressType.Work;
+            var vippsStreetAddress = "Vipps Street Address";
+            var region = "Oslo";
+            var country = "NO";
+            var postalCode = "0151";
+
+            mapper.MapVippsAddressFields(customerAddress, new VippsAddress
+            {
+                AddressType = vippsAddressType,
+                StreetAddress = vippsStreetAddress,
+                Region = region,
+                Country = country,
+                PostalCode = postalCode
+            });
+
+            Assert.Equal(vippsAddressType, customerAddress.GetVippsAddressType());
+            Assert.Equal(vippsStreetAddress, customerAddress.Line1);
+            Assert.Equal(region, customerAddress.City);
+            Assert.Equal(country, customerAddress.CountryCode);
+            Assert.Equal(postalCode, customerAddress.PostalCode);
+        }
+    }
+}

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginSanityCheckTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginSanityCheckTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Threading.Tasks;
+using Mediachase.Commerce.Customers;
+using Vipps.Login.Models;
+using Xunit;
+
+namespace Vipps.Login.Episerver.Commerce.Tests
+{
+    public class VippsLoginSanityCheckTests
+    {
+        [Fact]
+        public void IsValidContactFalseIfInputIsNull()
+        {
+            var sanityCheck = new VippsLoginSanityCheck();
+
+            Assert.False(sanityCheck.IsValidContact(null, null));
+            Assert.False(sanityCheck.IsValidContact(new CustomerContact(), null));
+            Assert.False(sanityCheck.IsValidContact(null, new VippsUserInfo()));
+        }
+
+        [Fact]
+        public void IsValidContactTrueIfFirstAndLastNameMatch()
+        {
+            var sanityCheck = new VippsLoginSanityCheck();
+
+            var firstName = "firstName";
+            var lastName = "lastName";
+            var contact = new CustomerContact
+            {
+                FirstName = firstName,
+                LastName = lastName
+            };
+            var userInfo = new VippsUserInfo
+            {
+                GivenName = firstName,
+                FamilyName = lastName
+            };
+
+            Assert.True(sanityCheck.IsValidContact(contact, userInfo));
+        }
+
+        [Fact]
+        public void IsValidContactFalseIfFirstAndLastNameDoNotMatch()
+        {
+            var sanityCheck = new VippsLoginSanityCheck();
+
+            var firstName = "firstName";
+            var lastName = "lastName";
+            var contact = new CustomerContact
+            {
+                FirstName = firstName,
+                LastName = lastName
+            };
+            var userInfo = new VippsUserInfo
+            {
+                GivenName = "xzxczcxz",
+                FamilyName = "asdasdds"
+            };
+
+            Assert.False(sanityCheck.IsValidContact(contact, userInfo));
+        }
+    }
+}

--- a/test/Vipps.Login.Episerver.Commerce.Tests/packages.config
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/packages.config
@@ -13,12 +13,22 @@
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net472" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.1.0" targetFramework="net472" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
+  <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net472" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net472" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net472" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net472" />

--- a/test/Vipps.Login.Tests/Vipps.Login.Tests.csproj
+++ b/test/Vipps.Login.Tests/Vipps.Login.Tests.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">


### PR DESCRIPTION
Implementing login flow explained by Vidar from Vipps:

> Even though the website might have separate entry points for registration of new users and login for existing users the functionality related to Vipps login should not differ between these two scenarios. If a new user ends up clicking "login" the merchant should create a new account and log the user into that. If an existing user clicks "register" the merchant should log the user into her existing account. This is because the user might not remember whether she has an account or not and the merchant can get the same information from Vipps login in both these cases.
> 
> Normally we recommend the checks related to login/registration to be like this:
> 
> 1. First check if you already have the unique user identifier for Vipps (called "sub" in the response from our API) stored on one of your accounts. If you have it, this means that the user has used Vipps on your site earlier and have an explicit link to the account. In this case use the ID to log the user into her account.
> 2. If you have not already stored the ID: check if the user already have an account based on phone number and e-mail address. If this gives a match on one (and only one) account, then you can use this to log the user into that account since both phone number and e-mail address is verified in Vipps. Before completing the link it is an advantage to do a "sanity check" on the name of the Vipps user to the name in the existing account to make sure that the account is not an old account where the user has abandoned  the phone number or e-mail address an this has been picked up by someone else at a later time.
> 3. If you get a match on multiple accounts you can provide information on this and offer the user the possibility to log in to her existing account (using the old login method) and then link the account to Vipps.

Vipps.Login.Episerver.Commerce now contains a default implementation to support this log in flow.
The readme explains how to implement it.