### PR TITLE
Feature/link account

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ You can add a ReturnUrl to redirect the user once they are logged in, for exampl
 
 Vipps is using the OpenIdConnect Authorization Code Grant flow, this means the user is redirected back to your environment with a Authorization token. The middleware will validate the token and exchange it for an `id_token` and an `access_token`. A `ClaimsIdentity` will be created which will contain the information of the scopes that you configured (email, name, addresses etc).
 
+### Link Vipps to an existing account
+
+If you want to allow **logged in users** to link to Vipps to their existing non Vipps account, you can add a link the redirect them to `https://{your-site}/vipps-login?LinkAccount=true`. When they visit that link, they will be redirected to Vipps and can go through the log in process. Once they're redirected back to your site, their Vipps account will be linked to their existing account. This means that they will now be able to use Vipps to access their existing account and they can sync their data from Vipps to Episerver.
+
 ### Customized 'sanity check' during login
 
 If the user tries to log in with Vipps and there is an existing account that matches the Vipps information (email or phone number), the library will execute a 'sanity check'. This is done to make sure that the account is not an old account where the user has abandoned the phone number or e-mail address an this has been picked up by someone else at a later time.

--- a/src/Vipps.Login.Episerver.Commerce/CustomerContactService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/CustomerContactService.cs
@@ -1,0 +1,12 @@
+﻿using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public class CustomerContactService : ICustomerContactService
+    {
+        public CustomerContact SaveChanges(CustomerContact contact)
+        {
+            return contact.SaveChanges();
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginLinkAccountException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginLinkAccountException.cs
@@ -4,9 +4,12 @@ namespace Vipps.Login.Episerver.Commerce.Exceptions
 {
     public class VippsLoginLinkAccountException : Exception
     {
-        public VippsLoginLinkAccountException(string message)
+        public VippsLoginLinkAccountException(string message, bool userError = false)
             : base(message)
         {
+            UserError = userError;
         }
+
+        public bool UserError { get; set; }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginLinkAccountException.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Exceptions/VippsLoginLinkAccountException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Vipps.Login.Episerver.Commerce.Exceptions
+{
+    public class VippsLoginLinkAccountException : Exception
+    {
+        public VippsLoginLinkAccountException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
@@ -15,9 +15,9 @@ namespace Vipps.Login.Episerver.Commerce.Extensions
             return contact[MetadataConstants.VippsSubjectGuidFieldName] as Guid?;
         }
 
-        public static void SetVippsLinkAccountToken(this CustomerContact contact, Guid? subjectGuid)
+        public static void SetVippsLinkAccountToken(this CustomerContact contact, Guid? accountTokenGuid)
         {
-            contact[MetadataConstants.VippsLinkAccountTokenFieldName] = subjectGuid;
+            contact[MetadataConstants.VippsLinkAccountTokenFieldName] = accountTokenGuid;
         }
 
         public static Guid? GetVippsLinkAccountToken(this CustomerContact contact)

--- a/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
@@ -17,12 +17,12 @@ namespace Vipps.Login.Episerver.Commerce.Extensions
 
         public static void SetVippsLinkAccountToken(this CustomerContact contact, Guid? subjectGuid)
         {
-            contact[MetadataConstants.VippsSubjectGuidFieldName] = subjectGuid;
+            contact[MetadataConstants.VippsLinkAccountTokenFieldName] = subjectGuid;
         }
 
         public static Guid? GetVippsLinkAccountToken(this CustomerContact contact)
         {
-            return contact[MetadataConstants.VippsSubjectGuidFieldName] as Guid?;
+            return contact[MetadataConstants.VippsLinkAccountTokenFieldName] as Guid?;
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Extensions/CustomerContactExtensions.cs
@@ -15,6 +15,14 @@ namespace Vipps.Login.Episerver.Commerce.Extensions
             return contact[MetadataConstants.VippsSubjectGuidFieldName] as Guid?;
         }
 
-        
+        public static void SetVippsLinkAccountToken(this CustomerContact contact, Guid? subjectGuid)
+        {
+            contact[MetadataConstants.VippsSubjectGuidFieldName] = subjectGuid;
+        }
+
+        public static Guid? GetVippsLinkAccountToken(this CustomerContact contact)
+        {
+            return contact[MetadataConstants.VippsSubjectGuidFieldName] as Guid?;
+        }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/ICustomerContactService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/ICustomerContactService.cs
@@ -1,0 +1,9 @@
+﻿using Mediachase.Commerce.Customers;
+
+namespace Vipps.Login.Episerver.Commerce
+{
+    public interface ICustomerContactService
+    {
+        CustomerContact SaveChanges(CustomerContact contact);
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Principal;
 using Mediachase.Commerce.Customers;
+using Microsoft.Owin;
 
 namespace Vipps.Login.Episerver.Commerce
 {
@@ -12,5 +13,8 @@ namespace Vipps.Login.Episerver.Commerce
         void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default);
         Guid CreateLinkAccountToken(CustomerContact contact);
         CustomerContact FindCustomerContactByLinkAccountToken(Guid linkAccountToken);
+        bool HandleLogin(IOwinContext context, VippsSyncOptions vippsSyncOptions = default, CustomerContact customerContact = null);
+        bool HandleLinkAccount(IOwinContext context, CustomerContact customerContact = null);
+        bool HandleRedirect(IOwinContext context, string returnUrl);
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
@@ -12,6 +12,7 @@ namespace Vipps.Login.Episerver.Commerce
         IEnumerable<CustomerContact> FindCustomerContacts(string email, string phone);
         void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default);
         Guid CreateLinkAccountToken(CustomerContact contact);
+        void RemoveLinkToVippsAccount(CustomerContact contact);
         CustomerContact FindCustomerContactByLinkAccountToken(Guid linkAccountToken);
         bool HandleLogin(IOwinContext context, VippsSyncOptions vippsSyncOptions = default, CustomerContact customerContact = null);
         bool HandleLinkAccount(IOwinContext context, CustomerContact customerContact = null);

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginCommerceService.cs
@@ -10,5 +10,7 @@ namespace Vipps.Login.Episerver.Commerce
         CustomerContact FindCustomerContact(Guid subjectGuid);
         IEnumerable<CustomerContact> FindCustomerContacts(string email, string phone);
         void SyncInfo(IIdentity identity, CustomerContact currentContact, VippsSyncOptions options = default);
+        Guid CreateLinkAccountToken(CustomerContact contact);
+        CustomerContact FindCustomerContactByLinkAccountToken(Guid linkAccountToken);
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/IVippsLoginDataLoader.cs
+++ b/src/Vipps.Login.Episerver.Commerce/IVippsLoginDataLoader.cs
@@ -7,6 +7,7 @@ namespace Vipps.Login.Episerver.Commerce
     public interface IVippsLoginDataLoader
     {
         IEnumerable<CustomerContact> FindContactsBySubjectGuid(Guid subjectGuid);
+        IEnumerable<CustomerContact> FindContactsByLinkAccountToken(Guid linkAccountToken);
         IEnumerable<CustomerContact> FindContactsByEmail(string email);
         IEnumerable<CustomerContact> FindContactsByPhone(string phone);
     }

--- a/src/Vipps.Login.Episerver.Commerce/Initialization/MetadataInitialization.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Initialization/MetadataInitialization.cs
@@ -14,6 +14,7 @@ namespace Vipps.Login.Episerver.Commerce.Initialization
         {
             CreateMetaField(AddressEntity.ClassName, MetadataConstants.VippsAddressTypeFieldName, MetadataConstants.VippsAddressTypeFriendlyName);
             CreateGuidMetaField(ContactEntity.ClassName, MetadataConstants.VippsSubjectGuidFieldName, MetadataConstants.VippsSubjectGuidFriendlyName);
+            CreateGuidMetaField(ContactEntity.ClassName, MetadataConstants.VippsLinkAccountTokenFieldName, MetadataConstants.VippsLinkAccountTokenFriendlyName);
         }
 
         private void CreateMetaField(string metaClassName, string metaFieldName, string friendlyName, bool isNullable = true, int maxLength = 255, bool isUnique = false)

--- a/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
+++ b/src/Vipps.Login.Episerver.Commerce/Initialization/VippsLoginCommerceInitialization.cs
@@ -17,6 +17,7 @@ namespace Vipps.Login.Episerver.Commerce.Initialization
 
         public void ConfigureContainer(ServiceConfigurationContext context)
         {
+            context.Services.AddTransient<ICustomerContactService, CustomerContactService>();
             context.Services.AddTransient<IVippsLoginCommerceService, VippsLoginCommerceService>();
             context.Services.AddTransient<IVippsLoginMapper, VippsLoginMapper>();
             context.Services.AddTransient<IVippsLoginDataLoader, VippsLoginDataLoader>();

--- a/src/Vipps.Login.Episerver.Commerce/MetadataConstants.cs
+++ b/src/Vipps.Login.Episerver.Commerce/MetadataConstants.cs
@@ -7,5 +7,8 @@
 
         public const string VippsSubjectGuidFieldName = "VippsSubjectGuid";
         public const string VippsSubjectGuidFriendlyName = "Vipps Subject Guid (used to identify user)";
+
+        public const string VippsLinkAccountTokenFieldName = "VippsLinkAccountToken";
+        public const string VippsLinkAccountTokenFriendlyName = "Vipps LinkAccount Token (used to link vipps user to existing account)";
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -265,6 +265,7 @@
     <Compile Include="IVippsLoginSanityCheck.cs" />
     <Compile Include="MetadataConstants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VippsConstants.cs" />
     <Compile Include="VippsLoginCommerceService.cs" />
     <Compile Include="VippsEpiNotifications.cs" />
     <Compile Include="VippsLoginDataLoader.cs" />

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -253,6 +253,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\VippsLoginLinkAccountException.cs" />
     <Compile Include="Exceptions\VippsLoginSanityCheckException.cs" />
     <Compile Include="Exceptions\VippsLoginException.cs" />
     <Compile Include="Extensions\AddressExtensions.cs" />

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -253,11 +253,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomerContactService.cs" />
     <Compile Include="Exceptions\VippsLoginLinkAccountException.cs" />
     <Compile Include="Exceptions\VippsLoginSanityCheckException.cs" />
     <Compile Include="Exceptions\VippsLoginException.cs" />
     <Compile Include="Extensions\AddressExtensions.cs" />
     <Compile Include="Extensions\CustomerContactExtensions.cs" />
+    <Compile Include="ICustomerContactService.cs" />
     <Compile Include="Initialization\MetadataInitialization.cs" />
     <Compile Include="Initialization\VippsLoginCommerceInitialization.cs" />
     <Compile Include="IVippsLoginCommerceService.cs" />

--- a/src/Vipps.Login.Episerver.Commerce/VippsConstants.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Vipps.Login.Episerver.Commerce
+{
+    public class VippsConstants
+    {
+        public const string LinkAccount = "link-account";
+    }
+}

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Principal;
-using System.Threading.Tasks;
 using EPiServer.Logging;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
@@ -106,6 +105,13 @@ namespace Vipps.Login.Episerver.Commerce
             }
         }
 
+        public void RemoveLinkToVippsAccount(CustomerContact contact)
+        {
+            if (contact == null) throw new ArgumentNullException(nameof(contact));
+            contact.SetVippsSubject(null);
+            _customerContactService.SaveChanges(contact);
+        }
+
         public CustomerContact FindCustomerContactByLinkAccountToken(Guid linkAccountToken)
         {
             var contacts = _vippsLoginDataLoader.FindContactsByLinkAccountToken(linkAccountToken).ToList();
@@ -150,6 +156,7 @@ namespace Vipps.Login.Episerver.Commerce
             {
                 throw new InvalidOperationException();
             }
+
             var isVippsIdentity = _vippsLoginService
                 .IsVippsIdentity(context.Authentication.User.Identity);
             if (isVippsIdentity)

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginCommerceService.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security.Principal;
 using EPiServer.Logging;
 using Vipps.Login.Episerver.Commerce.Extensions;
-using Vipps.Login.Models;
 
 namespace Vipps.Login.Episerver.Commerce
 {
@@ -25,7 +24,7 @@ namespace Vipps.Login.Episerver.Commerce
             _vippsLoginMapper = vippsLoginMapper;
             _vippsLoginDataLoader = vippsLoginDataLoader;
         }
-
+        
         public CustomerContact FindCustomerContact(Guid subjectGuid)
         {
             var contacts = _vippsLoginDataLoader.FindContactsBySubjectGuid(subjectGuid).ToList();
@@ -99,6 +98,26 @@ namespace Vipps.Login.Episerver.Commerce
             {
                 currentContact.SaveChanges();
             }
+        }
+
+        public CustomerContact FindCustomerContactByLinkAccountToken(Guid linkAccountToken)
+        {
+            var contacts = _vippsLoginDataLoader.FindContactsByLinkAccountToken(linkAccountToken).ToList();
+            if (contacts.Count() > 1)
+            {
+                Logger.Warning(
+                    $"Vipps.Login: found more than one account for subjectGuid {linkAccountToken}. Fallback to use first result.");
+            }
+
+            return contacts.FirstOrDefault();
+        }
+
+        public Guid CreateLinkAccountToken(CustomerContact contact)
+        {
+            var token = Guid.NewGuid();
+            contact.SetVippsLinkAccountToken(token);
+            contact.SaveChanges();
+            return token;
         }
     }
 }

--- a/src/Vipps.Login.Episerver.Commerce/VippsLoginDataLoader.cs
+++ b/src/Vipps.Login.Episerver.Commerce/VippsLoginDataLoader.cs
@@ -41,6 +41,28 @@ namespace Vipps.Login.Episerver.Commerce
             }
         }
 
+        public IEnumerable<CustomerContact> FindContactsByLinkAccountToken(Guid linkAccountToken)
+        {
+            try
+            {
+                return BusinessManager
+                    .List(ContactEntity.ClassName, new[]
+                    {
+                        new FilterElement(
+                            MetadataConstants.VippsLinkAccountTokenFieldName,
+                            FilterElementType.Equal,
+                            linkAccountToken
+                        )
+                    })
+                    .OfType<CustomerContact>();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Vipps.Login: could not load contacts by linkAccountToken", ex);
+                return Enumerable.Empty<CustomerContact>();
+            }
+        }
+
         public virtual IEnumerable<CustomerContact> FindContactsByEmail(string email)
         {
             if (string.IsNullOrWhiteSpace(email))

--- a/src/Vipps.Login/VippsLoginService.cs
+++ b/src/Vipps.Login/VippsLoginService.cs
@@ -33,8 +33,8 @@ namespace Vipps.Login
                 return null;
             }
 
-            var subjectClaim = identity.FindFirst(ClaimTypes.NameIdentifier) ??
-                               identity.FindFirst(JwtClaimTypes.Subject);
+            var subjectClaim = identity.FindFirst(JwtClaimTypes.Subject) ??
+                               identity.FindFirst(ClaimTypes.NameIdentifier);
             if (!Guid.TryParse(subjectClaim?.Value, out var subject))
             {
                 return null;
@@ -43,15 +43,16 @@ namespace Vipps.Login
             return new VippsUserInfo
             {
                 Sub = subject,
-                BirthDate = ParseDate(identity.FindFirst(ClaimTypes.DateOfBirth) ??
-                                      identity.FindFirst(JwtClaimTypes.BirthDate)),
-                Email = ParseString(identity.FindFirst(ClaimTypes.Email) ?? identity.FindFirst(JwtClaimTypes.Email)),
+                BirthDate = ParseDate(identity.FindFirst(JwtClaimTypes.BirthDate) ??
+                                      identity.FindFirst(ClaimTypes.DateOfBirth)),
+                Email = ParseString(identity.FindFirst(JwtClaimTypes.Email) ??
+                                    identity.FindFirst(ClaimTypes.Email)),
                 EmailVerified = ParseBool(identity.FindFirst(JwtClaimTypes.EmailVerified)),
-                FamilyName = ParseString(identity.FindFirst(ClaimTypes.Surname) ??
-                                         identity.FindFirst(JwtClaimTypes.FamilyName)),
-                GivenName = ParseString(identity.FindFirst(ClaimTypes.GivenName) ??
-                                        identity.FindFirst(JwtClaimTypes.GivenName)),
-                Name = ParseString(identity.FindFirst(ClaimTypes.Name) ?? identity.FindFirst(JwtClaimTypes.Name)),
+                FamilyName = ParseString(identity.FindFirst(JwtClaimTypes.FamilyName) ??
+                                         identity.FindFirst(ClaimTypes.Surname)),
+                GivenName = ParseString(identity.FindFirst(JwtClaimTypes.GivenName) ??
+                                        identity.FindFirst(ClaimTypes.GivenName)),
+                Name = ParseString(identity.FindFirst(JwtClaimTypes.Name) ?? identity.FindFirst(ClaimTypes.Name)),
                 PhoneNumber = ParseString(identity.FindFirst(JwtClaimTypes.PhoneNumber) ??
                                           identity.FindFirst(ClaimTypes.HomePhone) ??
                                           identity.FindFirst(ClaimTypes.MobilePhone) ??
@@ -72,12 +73,14 @@ namespace Vipps.Login
             {
                 return false;
             }
+
             var issuer = identity.FindFirst(JwtClaimTypes.Issuer);
             var validIssuers = GetValidIssuers();
             if (issuer == null)
             {
                 return false;
             }
+
             return validIssuers.Any(validIssuer => issuer.Value.StartsWith(validIssuer));
         }
 
@@ -104,6 +107,7 @@ namespace Vipps.Login
             {
                 return null;
             }
+
             return JsonConvert.DeserializeObject<VippsAddress>(claim.Value);
         }
 

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsEpiNotificationsTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsEpiNotificationsTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using EPiServer.Security;
 using FakeItEasy;
 using Mediachase.Commerce.Customers;
+using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
@@ -30,7 +33,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
                 A.Fake<IVippsLoginSanityCheck>(),
                 A.Fake<MapUserKey>()
             );
-            
+
             await Assert.ThrowsAsync<VippsLoginException>(async () =>
                 await notifications.DefaultSecurityTokenValidated(CreateContext()));
         }
@@ -68,7 +71,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
                     Email = testEmail,
                     PhoneNumber = testPhoneNumber
                 });
-            
+
             // No contact with subject guid
             var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
             A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
@@ -101,7 +104,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var vippsCommerceService = A.Fake<IVippsLoginCommerceService>();
             A.CallTo(() => vippsCommerceService.FindCustomerContact(A<Guid>._))
                 .Returns(new CustomerContact() {UserId = testEmail});
-           
+
             var notifications = new VippsEpiNotifications(
                 A.Fake<ISynchronizingUserService>(),
                 A.Fake<IVippsLoginService>(),
@@ -144,7 +147,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
 
             // Find with phone or by email
             A.CallTo(() => vippsCommerceService.FindCustomerContacts(testEmail, testPhoneNumber))
-                .Returns(new [] { new CustomerContact { UserId = testEmail } });
+                .Returns(new[] {new CustomerContact {UserId = testEmail}});
 
             var sanityCheck = A.Fake<IVippsLoginSanityCheck>();
             A.CallTo(() => sanityCheck.IsValidContact(A<CustomerContact>._, A<VippsUserInfo>._))
@@ -193,7 +196,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
 
             // Find with phone or by email
             A.CallTo(() => vippsCommerceService.FindCustomerContacts(testEmail, testPhoneNumber))
-                .Returns(new[] { new CustomerContact { UserId = testEmail } });
+                .Returns(new[] {new CustomerContact {UserId = testEmail}});
 
             // Failing sanity check
             var sanityCheck = A.Fake<IVippsLoginSanityCheck>();
@@ -238,7 +241,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
 
             // Find multiple with phone or by email
             A.CallTo(() => vippsCommerceService.FindCustomerContacts(testEmail, testPhoneNumber))
-                .Returns(new[] { new CustomerContact() { UserId = testEmail }, new CustomerContact() { UserId = $"{testEmail}1" } });
+                .Returns(new[]
+                    {new CustomerContact() {UserId = testEmail}, new CustomerContact() {UserId = $"{testEmail}1"}});
 
             var notifications = new VippsEpiNotifications(
                 A.Fake<ISynchronizingUserService>(),
@@ -254,7 +258,98 @@ namespace Vipps.Login.Episerver.Commerce.Tests
                 await notifications.DefaultSecurityTokenValidated(context));
         }
 
-        private SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions> CreateContext()
+        [Fact]
+        public async Task RedirectToIdentityProviderReturns403()
+        {
+            var notifications = new VippsEpiNotifications(
+                A.Fake<HttpClient>(),
+                A.Fake<ISynchronizingUserService>(),
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginCommerceService>(),
+                A.Fake<IVippsLoginSanityCheck>(),
+                A.Fake<MapUserKey>());
+
+            var configurationManager =
+                A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
+
+            var context = A.Fake<IOwinContext>();
+            var response = new OwinResponse()
+            {
+                StatusCode = 401
+            };
+            A.CallTo(() => context.Response).Returns(response);
+            var request = A.Fake<IOwinRequest>();
+            A.CallTo(() => request.Uri).ReturnsLazily(() => new Uri("https://test.com/asdf"));
+            A.CallTo(() => context.Request).Returns(request);
+
+            var user = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => context.Authentication.User).Returns(user);
+            A.CallTo(() => user.Identity.IsAuthenticated).Returns(true);
+
+            var notification =
+                new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(
+                    context,
+                    new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority")
+                    {
+                        ConfigurationManager = configurationManager
+                    })
+                {
+                    ProtocolMessage = new OpenIdConnectMessage()
+                };
+            await notifications.RedirectToIdentityProvider(notification);
+            Assert.Equal(403, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RedirectToIdentityProviderDoesNotReturn403ForLinkAccount()
+        {
+            var notifications = new VippsEpiNotifications(
+                A.Fake<HttpClient>(),
+                A.Fake<ISynchronizingUserService>(),
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginCommerceService>(),
+                A.Fake<IVippsLoginSanityCheck>(),
+                A.Fake<MapUserKey>());
+
+            var configurationManager =
+                A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
+
+            var context = A.Fake<IOwinContext>();
+            var response = new OwinResponse()
+            {
+                StatusCode = 401
+            };
+            A.CallTo(() => context.Response).Returns(response);
+            var request = A.Fake<IOwinRequest>();
+            A.CallTo(() => request.Uri).ReturnsLazily(() => new Uri("https://test.com/asdf"));
+            A.CallTo(() => context.Request).Returns(request);
+
+            var properties = new AuthenticationProperties();
+            properties.Dictionary.Add(VippsConstants.LinkAccount, VippsConstants.LinkAccount);
+            A.CallTo(() => context.Authentication.AuthenticationResponseChallenge)
+                .Returns(new AuthenticationResponseChallenge(new[] { "" }, properties));
+
+            var notification =
+                new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(
+                    context,
+                    new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority")
+                    {
+                        ConfigurationManager = configurationManager
+                    })
+                {
+                    ProtocolMessage = new OpenIdConnectMessage()
+                };
+
+            await notifications.RedirectToIdentityProvider(notification);
+            Assert.NotEqual(403, response.StatusCode);
+        }
+
+        private SecurityTokenValidatedNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>
+            CreateContext()
         {
             var options =
                 new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority");

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
@@ -79,6 +79,69 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             Assert.NotEqual(expectedContact, contact);
         }
 
+        [Fact]
+        public void FindCustomerContactByLinkAccountTokenShouldBeNull()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>());
+
+            var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
+            Assert.Null(contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactByLinkAccountTokenShouldReturnContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
+                .Returns(new[] { expectedContact });
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
+            Assert.Equal(expectedContact, contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactByLinkAccountTokenShouldReturnFirstContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
+                .Returns(new[] { expectedContact, new CustomerContact() });
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
+            Assert.Equal(expectedContact, contact);
+        }
+
+        [Fact]
+        public void FindCustomerContactByLinkAccountTokenShouldReturnNotEqualLastContact()
+        {
+            var expectedContact = new CustomerContact();
+            var dataLoader = A.Fake<IVippsLoginDataLoader>();
+            A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
+                .Returns(new[] { new CustomerContact(), expectedContact });
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                dataLoader
+            );
+
+            var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
+            Assert.NotEqual(expectedContact, contact);
+        }
+
 
         [Fact]
         public void FindCustomerContactsShouldBeEmpty()

--- a/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/VippsLoginCommerceServiceTests.cs
@@ -2,13 +2,11 @@
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Principal;
-using System.Threading.Tasks;
-using EPiServer.Events.ChangeNotification.Implementation;
-using EPiServer.Security;
 using FakeItEasy;
 using Mediachase.BusinessFoundation.Data;
 using Mediachase.Commerce.Customers;
-using Vipps.Login.Episerver.Commerce.Exceptions;
+using Microsoft.Owin;
+using Microsoft.Owin.Security;
 using Vipps.Login.Models;
 using Xunit;
 
@@ -22,7 +20,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(), A.Fake<ICustomerContactService>());
 
             var contact = service.FindCustomerContact(Guid.Empty);
             Assert.Null(contact);
@@ -38,7 +36,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContact(Guid.Empty);
@@ -55,7 +54,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContact(Guid.Empty);
@@ -72,7 +72,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContact(Guid.Empty);
@@ -85,7 +86,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(), A.Fake<ICustomerContactService>());
 
             var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
             Assert.Null(contact);
@@ -97,11 +98,12 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var expectedContact = new CustomerContact();
             var dataLoader = A.Fake<IVippsLoginDataLoader>();
             A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
-                .Returns(new[] { expectedContact });
+                .Returns(new[] {expectedContact});
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
@@ -114,11 +116,12 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var expectedContact = new CustomerContact();
             var dataLoader = A.Fake<IVippsLoginDataLoader>();
             A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
-                .Returns(new[] { expectedContact, new CustomerContact() });
+                .Returns(new[] {expectedContact, new CustomerContact()});
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
@@ -131,11 +134,12 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var expectedContact = new CustomerContact();
             var dataLoader = A.Fake<IVippsLoginDataLoader>();
             A.CallTo(() => dataLoader.FindContactsByLinkAccountToken(A<Guid>._))
-                .Returns(new[] { new CustomerContact(), expectedContact });
+                .Returns(new[] {new CustomerContact(), expectedContact});
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader
+                dataLoader,
+                A.Fake<ICustomerContactService>()
             );
 
             var contact = service.FindCustomerContactByLinkAccountToken(Guid.Empty);
@@ -149,7 +153,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
 
             var contact = service.FindCustomerContacts(string.Empty, string.Empty);
             Assert.Empty(contact);
@@ -170,7 +175,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader);
+                dataLoader,
+                A.Fake<ICustomerContactService>());
 
             var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
 
@@ -192,7 +198,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader);
+                dataLoader,
+                A.Fake<ICustomerContactService>());
 
             var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
 
@@ -216,7 +223,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                dataLoader);
+                dataLoader,
+                A.Fake<ICustomerContactService>());
 
             var contacts = service.FindCustomerContacts(string.Empty, string.Empty);
 
@@ -229,7 +237,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 A.Fake<IVippsLoginService>(),
                 A.Fake<IVippsLoginMapper>(),
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
 
             Assert.Throws<ArgumentNullException>(() => service.SyncInfo(null, null));
             Assert.Throws<ArgumentNullException>(() => service.SyncInfo(new ClaimsIdentity(), null));
@@ -250,7 +259,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 loginService,
                 mapper,
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
 
             service.SyncInfo(new ClaimsIdentity(), customerContact, new VippsSyncOptions
             {
@@ -260,6 +270,35 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             });
 
             A.CallTo(() => mapper.MapVippsContactFields(A<CustomerContact>._, A<VippsUserInfo>._)).MustHaveHappened();
+        }
+
+        [Fact]
+        public void SyncInfoShouldSaveChanges()
+        {
+            var customerContact = A.Fake<CustomerContact>();
+            var userinfo = new VippsUserInfo()
+            {
+                Addresses = Enumerable.Empty<VippsAddress>()
+            };
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.GetVippsUserInfo(A<ClaimsIdentity>._)).Returns(userinfo);
+
+            var customerContactService = A.Fake<ICustomerContactService>();
+            var mapper = A.Fake<IVippsLoginMapper>();
+            var service = new VippsLoginCommerceService(
+                loginService,
+                mapper,
+                A.Fake<IVippsLoginDataLoader>(),
+                customerContactService);
+
+            service.SyncInfo(new ClaimsIdentity(), customerContact, new VippsSyncOptions
+            {
+                SyncContactInfo = false,
+                SyncAddresses = false,
+                ShouldSaveContact = true,
+            });
+
+            A.CallTo(() => customerContactService.SaveChanges(A<CustomerContact>._)).MustHaveHappened();
         }
 
         [Fact]
@@ -275,7 +314,8 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 loginService,
                 mapper,
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
 
             service.SyncInfo(new ClaimsIdentity(), new CustomerContact(), new VippsSyncOptions
             {
@@ -295,7 +335,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var userInfo = new VippsUserInfo()
             {
                 Sub = Guid.NewGuid(),
-                Addresses = new[] {new VippsAddress(), new VippsAddress() }
+                Addresses = new[] {new VippsAddress(), new VippsAddress()}
             };
             var identity = new ClaimsIdentity();
             var loginService = A.Fake<IVippsLoginService>();
@@ -306,7 +346,7 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             var service = new VippsLoginCommerceService(
                 loginService,
                 mapper,
-                A.Fake<IVippsLoginDataLoader>());
+                A.Fake<IVippsLoginDataLoader>(), A.Fake<ICustomerContactService>());
 
             service.SyncInfo(identity, contact, new VippsSyncOptions
             {
@@ -318,6 +358,160 @@ namespace Vipps.Login.Episerver.Commerce.Tests
             A.CallTo(() => mapper.MapAddress(null, CustomerAddressTypeEnum.Billing, null, String.Empty))
                 .WithAnyArguments()
                 .MustHaveHappenedTwiceExactly();
+        }
+
+        [Fact]
+        public void HandleLoginUnauthorizedUserReturnsTrue()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            var context = A.Fake<IOwinContext>();
+            Assert.True(service.HandleLogin(context));
+
+            A.CallTo(() => context.Authentication.Challenge(VippsAuthenticationDefaults.AuthenticationType))
+                .MustHaveHappened();
+        }
+
+        [Fact]
+        public void HandleLoginAuthorizedUserReturnsFalse()
+        {
+            var context = A.Fake<IOwinContext>();
+            var user = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => context.Authentication.User).Returns(user);
+            A.CallTo(() => user.Identity.IsAuthenticated).Returns(true);
+
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            Assert.False(service.HandleLogin(
+                context,
+                new VippsSyncOptions {ShouldSaveContact = false}, customerContact:
+                new CustomerContact()));
+
+            A.CallTo(() => context.Authentication.Challenge(VippsAuthenticationDefaults.AuthenticationType))
+                .MustNotHaveHappened();
+        }
+
+        [Fact]
+        public void HandleHandleLinkAccountThrowsForNonAuthenticatedUser()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            Assert.Throws<InvalidOperationException>(() => service.HandleLinkAccount(A.Fake<IOwinContext>()));
+        }
+
+        [Fact]
+        public void HandleHandleLinkAccountReturnsFalseForVippsUser()
+        {
+            var context = A.Fake<IOwinContext>();
+            var user = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => context.Authentication.User).Returns(user);
+            A.CallTo(() => user.Identity.IsAuthenticated).Returns(true);
+
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.IsVippsIdentity(A<IIdentity>._)).Returns(true);
+
+            var service = new VippsLoginCommerceService(
+                loginService,
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            Assert.False(service.HandleLinkAccount(context));
+        }
+
+        [Fact]
+        public void HandleHandleLinkAccountReturnsTrueForNonVippsUser()
+        {
+            var context = A.Fake<IOwinContext>();
+            var user = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => context.Authentication.User).Returns(user);
+            A.CallTo(() => user.Identity.IsAuthenticated).Returns(true);
+
+            var loginService = A.Fake<IVippsLoginService>();
+            A.CallTo(() => loginService.IsVippsIdentity(A<IIdentity>._)).Returns(false);
+
+            var customerContactService = A.Fake<ICustomerContactService>();
+
+            var service = new VippsLoginCommerceService(
+                loginService,
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                customerContactService);
+
+            Assert.True(service.HandleLinkAccount(context, new CustomerContact()));
+
+            A.CallTo(() =>
+                    context.Authentication.Challenge(A<AuthenticationProperties>._,
+                        VippsAuthenticationDefaults.AuthenticationType))
+                .WhenArgumentsMatch((args) =>
+                {
+                    // Verify link account token
+                    var props = args[0] as AuthenticationProperties;
+                    if (props?.Dictionary == null ||
+                        !props.Dictionary.ContainsKey(VippsConstants.LinkAccount) ||
+                        !Guid.TryParse(props.Dictionary[VippsConstants.LinkAccount], out _))
+                    {
+                        return false;
+                    }
+
+                    // Verify auth type
+                    if (!(args[1] is string[] types) ||
+                        !types.Contains(VippsAuthenticationDefaults.AuthenticationType))
+                    {
+                        return false;
+                    }
+
+                    return true;
+                })
+                .MustHaveHappened();
+
+            // Verify storing link account token on account
+            A.CallTo(() => customerContactService.SaveChanges(A<CustomerContact>._))
+                .MustHaveHappened();
+        }
+
+        [Fact]
+        public void HandleRedirect()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            var context = A.Fake<IOwinContext>();
+
+            Assert.True(service.HandleRedirect(context, "/redirect-url"));
+
+            A.CallTo(() => context.Response.Redirect("/redirect-url")).MustHaveHappened();
+        }
+
+        [Fact]
+        public void HandleRedirectToLocalUrlOnly()
+        {
+            var service = new VippsLoginCommerceService(
+                A.Fake<IVippsLoginService>(),
+                A.Fake<IVippsLoginMapper>(),
+                A.Fake<IVippsLoginDataLoader>(),
+                A.Fake<ICustomerContactService>());
+
+            var context = A.Fake<IOwinContext>();
+            
+            Assert.True(service.HandleRedirect(context, "https://test.url/redirect-url"));
+
+            A.CallTo(() => context.Response.Redirect("/redirect-url")).MustHaveHappened();
         }
     }
 }

--- a/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
+++ b/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
@@ -19,6 +19,13 @@ namespace Vipps.Login.Tests
         }
 
         [Fact]
+        public void NotIsVippsIdentityForNullIdentity()
+        {
+            var service = new VippsLoginService();
+            Assert.False(service.IsVippsIdentity(null));
+        }
+
+        [Fact]
         public void NotIsVippsIdentityForUnknownIssuer()
         {
             var service = new VippsLoginService();
@@ -87,23 +94,85 @@ namespace Vipps.Login.Tests
             Assert.Equal(new DateTime(2020, 6, 30), userInfo.BirthDate);
         }
 
+        [Fact]
+        public void MapsClaims()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+            
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(_subClaim.Value.ToLowerInvariant(), userInfo.Sub.ToString().ToLowerInvariant());
+            Assert.Equal(_emailClaim.Value, userInfo.Email);
+            Assert.Equal(_familyNameClaim.Value, userInfo.FamilyName);
+            Assert.Equal(_givenNameClaim.Value, userInfo.GivenName);
+            Assert.Equal(_nameClaim.Value, userInfo.Name);
+            Assert.Equal(_phoneNumberClaim.Value, userInfo.PhoneNumber);
+        }
+
+        [Fact]
+        public void PrefersJwtClaims()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+
+            identity.AddClaims(new []
+            {
+                _subClaimJwt,
+                _emailClaimJwt,
+                _familyNameClaimJwt,
+                _givenNameClaimJwt,
+                _nameClaimJwt,
+                _phoneNumberClaimJwt,
+            });
+
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(_subClaimJwt.Value, userInfo.Sub.ToString());
+            Assert.Equal(_emailClaimJwt.Value, userInfo.Email);
+            Assert.Equal(_familyNameClaimJwt.Value, userInfo.FamilyName);
+            Assert.Equal(_givenNameClaimJwt.Value, userInfo.GivenName);
+            Assert.Equal(_nameClaimJwt.Value, userInfo.Name);
+            Assert.Equal(_phoneNumberClaimJwt.Value, userInfo.PhoneNumber);
+        }
+
         private ClaimsIdentity CreateIdentity()
         {
             var identity = new ClaimsIdentity();
             identity.AddClaims(new List<Claim>
             {
                 _issuerClaim,
-                _nameIdentifierClaim,
+                _subClaim,
+                _emailClaim,
+                _birthDateClaim,
+                _familyNameClaim,
+                _givenNameClaim,
+                _nameClaim,
+                _phoneNumberClaim,
+                _nninClaim
             });
             return identity;
         }
 
-        private readonly Claim _issuerClaim =
-            new Claim(JwtClaimTypes.Issuer, VippsLoginService.VippsTestApi);
-        private readonly Claim _nameIdentifierClaim =
-            new Claim(ClaimTypes.NameIdentifier, "3086A8D1-0AE2-4028-B5A8-D41628DDC9E8");
-        private readonly Claim _birthDateClaim =
-            new Claim(ClaimTypes.DateOfBirth, "30.6.2020");
+        private readonly Claim _issuerClaim = CreateClaim(JwtClaimTypes.Issuer, VippsLoginService.VippsTestApi);
+        private readonly Claim _subClaim = CreateClaim(ClaimTypes.NameIdentifier, "3086A8D1-0AE2-4028-B5A8-D41628DDC9E8");
+        private readonly Claim _birthDateClaim = CreateClaim(ClaimTypes.DateOfBirth, "30.6.2020");
+        private readonly Claim _emailClaim = CreateClaim(ClaimTypes.Email);
+        private readonly Claim _familyNameClaim = CreateClaim(ClaimTypes.Surname);
+        private readonly Claim _givenNameClaim = CreateClaim(ClaimTypes.GivenName);
+        private readonly Claim _nameClaim = CreateClaim(ClaimTypes.Name);
+        private readonly Claim _phoneNumberClaim = CreateClaim(ClaimTypes.HomePhone);
+        private readonly Claim _nninClaim = CreateClaim(VippsClaimTypes.Nnin);
+
+        private readonly Claim _subClaimJwt = CreateClaim(JwtClaimTypes.Subject, Guid.NewGuid().ToString());
+        private readonly Claim _emailClaimJwt = CreateClaim(JwtClaimTypes.Email);
+        private readonly Claim _familyNameClaimJwt = CreateClaim(JwtClaimTypes.FamilyName);
+        private readonly Claim _givenNameClaimJwt = CreateClaim(JwtClaimTypes.GivenName);
+        private readonly Claim _nameClaimJwt = CreateClaim(JwtClaimTypes.Name);
+        private readonly Claim _phoneNumberClaimJwt = CreateClaim(JwtClaimTypes.PhoneNumber);
+
+        private static Claim CreateClaim(string claimType, string claimValue = null)
+        {
+            return new Claim(claimType, claimValue ?? claimType);
+        }
 
         private readonly Claim _address1 = new Claim(JwtClaimTypes.Address, "{\"address_type\": \"home\",\"country\": \"NO\",\"formatted\": \"BOKS 6300, ETTERSTAD\n0603\nOSLO\nNO\",\"postal_code\": \"0603\",\"region\": \"OSLO\",\"street_address\": \"BOKS 6300, ETTERSTAD\"}");
         private readonly Claim _address2 = new Claim(JwtClaimTypes.Address, "{\"address_type\": \"work\",\"country\": \"NO\",\"formatted\": \"Skippergata 4\n0152\nOslo\nNO\",\"postal_code\": \"0152\",\"region\": \"Oslo\",\"street_address\": \"Skippergata 4\"}");

--- a/test/Vipps.Login.Tests/VippsOpenIdConnectAuthenticationNotificationsTests.cs
+++ b/test/Vipps.Login.Tests/VippsOpenIdConnectAuthenticationNotificationsTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Configuration;
+using System.Net.Http;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -7,6 +10,7 @@ using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Notifications;
+using Microsoft.Owin.Security.OpenIdConnect;
 using Xunit;
 
 namespace Vipps.Login.Tests
@@ -28,7 +32,8 @@ namespace Vipps.Login.Tests
 
             var configurationManager =
                 A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
-            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._)).Returns(new OpenIdConnectConfiguration());
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
 
             var notification = new AuthorizationCodeReceivedNotification(
                 A.Fake<IOwinContext>(),
@@ -41,7 +46,7 @@ namespace Vipps.Login.Tests
                 Code = "AuthCode"
             };
             await notifications.AuthorizationCodeReceived(notification);
-            
+
             Assert.Equal("abcde", notification.TokenEndpointResponse.AccessToken);
             Assert.Equal("qwerty", notification.TokenEndpointResponse.IdToken);
         }
@@ -61,7 +66,8 @@ namespace Vipps.Login.Tests
 
             var configurationManager =
                 A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
-            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._)).Returns(new OpenIdConnectConfiguration());
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
 
             var notification = new AuthorizationCodeReceivedNotification(
                 A.Fake<IOwinContext>(),
@@ -73,7 +79,81 @@ namespace Vipps.Login.Tests
                 RedirectUri = "https://redirect-url",
                 Code = "AuthCode"
             };
-            await Assert.ThrowsAsync<OpenIdConnectProtocolException>(async () => await notifications.AuthorizationCodeReceived(notification));
+            await Assert.ThrowsAsync<OpenIdConnectProtocolException>(async () =>
+                await notifications.AuthorizationCodeReceived(notification));
+        }
+
+        [Fact]
+        public async Task ThrowsIfNotUsingHttps()
+        {
+            var notifications = new VippsOpenIdConnectAuthenticationNotifications(A.Fake<HttpClient>());
+
+            var configurationManager =
+                A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
+
+            var context = A.Fake<IOwinContext>();
+            var response = new OwinResponse()
+            {
+                StatusCode = 401
+            };
+            A.CallTo(() => context.Response).Returns(response);
+            var request = A.Fake<IOwinRequest>();
+            A.CallTo(() => request.Uri).ReturnsLazily(() => new Uri("http://test.com/asdf"));
+            A.CallTo(() => context.Request).Returns(request);
+
+
+            var notification =
+                new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(
+                    context,
+                    new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority")
+                    {
+                        ConfigurationManager = configurationManager
+                    })
+                {
+                    ProtocolMessage = new OpenIdConnectMessage()
+                };
+            await Assert.ThrowsAsync<ConfigurationErrorsException>(async () =>
+                await notifications.RedirectToIdentityProvider(notification));
+        }
+
+        [Fact]
+        public async Task RedirectToIdentityProviderReturns403()
+        {
+            var notifications = new VippsOpenIdConnectAuthenticationNotifications(A.Fake<HttpClient>());
+
+            var configurationManager =
+                A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration());
+
+            var context = A.Fake<IOwinContext>();
+            var response = new OwinResponse()
+            {
+                StatusCode = 401
+            };
+            A.CallTo(() => context.Response).Returns(response);
+            var request = A.Fake<IOwinRequest>();
+            A.CallTo(() => request.Uri).ReturnsLazily(() => new Uri("https://test.com/asdf"));
+            A.CallTo(() => context.Request).Returns(request);
+
+            var user = A.Fake<ClaimsPrincipal>();
+            A.CallTo(() => context.Authentication.User).Returns(user);
+            A.CallTo(() => user.Identity.IsAuthenticated).Returns(true);
+
+            var notification =
+                new RedirectToIdentityProviderNotification<OpenIdConnectMessage, OpenIdConnectAuthenticationOptions>(
+                    context,
+                    new VippsOpenIdConnectAuthenticationOptions("clientId", "clientSecret", "authority")
+                    {
+                        ConfigurationManager = configurationManager
+                    })
+                {
+                    ProtocolMessage = new OpenIdConnectMessage()
+                };
+            await notifications.RedirectToIdentityProvider(notification);
+            Assert.Equal(403, response.StatusCode);
         }
     }
 }


### PR DESCRIPTION
Implementing step 4 of login flow explained by Vidar from Vipps:

> Even though the website might have separate entry points for registration of new users and login for existing users the functionality related to Vipps login should not differ between these two scenarios. If a new user ends up clicking "login" the merchant should create a new account and log the user into that. If an existing user clicks "register" the merchant should log the user into her existing account. This is because the user might not remember whether she has an account or not and the merchant can get the same information from Vipps login in both these cases.
> 
> Normally we recommend the checks related to login/registration to be like this:
> 
> 1. First check if you already have the unique user identifier for Vipps (called "sub" in the response from our API) stored on one of your accounts. If you have it, this means that the user has used Vipps on your site earlier and have an explicit link to the account. In this case use the ID to log the user into her account.
> 2. If you have not already stored the ID: check if the user already have an account based on phone number and e-mail address. If this gives a match on one (and only one) account, then you can use this to log the user into that account since both phone number and e-mail address is verified in Vipps. Before completing the link it is an advantage to do a "sanity check" on the name of the Vipps user to the name in the existing account to make sure that the account is not an old account where the user has abandoned  the phone number or e-mail address an this has been picked up by someone else at a later time.
> 3. If you get a match on multiple accounts you can provide information on this and offer the user the possibility to log in to her existing account (using the old login method) and then link the account to Vipps.
> 4. **It is also recommended on "my page" or similar in the website to provide the option for logged in users that has not yet linked their profile to Vipps to do so, for an easier login the next time. This just means to provide the "login with Vipps"-button and linking the ID from Vipps with this account.**

It'll redirect a logged in user to Vipps, once they completed log in their existing account will be linked to the Vipps account (meaning you can use your user credentials or Vipps to log into that account).